### PR TITLE
Bug 1299476 - Fix device name for flamingo r=gerard-majax

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DEVICE=tianchi
+DEVICE=flamingo
 MANUFACTURER=sony
 STOCK=18.5.C.0.25
 


### PR DESCRIPTION
The device name is erroneously reported as `tianchi`, while the correct name is `flamingo`. This leads the build process to create a `backup-tianchi` folder instead of `backup-flamingo`. The PR simply fix the name.
